### PR TITLE
Updated the PostgreSQL setup for pgAdmin and Vagrant

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,13 +1,32 @@
-#hey, don't check in passwords here.
+# PostgreSQL parameters are provided here for the
+# development and testing environments ONLY.
+
+# Use the test_app.sh script to AUTOMATICALLY configure PostgreSQL to
+# allow this Rails app to work in your development environment.  If you
+# are working on this app in the Vagrant environment, you can view the
+# development environment database with pgAdmin from your host OS.
+
+# pgAdmin parameters for the setup at
+# https://github.com/jhsu802701/vagrant-debian-jessie-rbenv-rubymn:
+
+# Host: localhost
+# Port: 15432
+# Maintenance DB: postgres
+# Username: rubymn_user
+# Password: rubymn_password
+
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+  timeout: 5000
+  username: rubymn_user
+  password: rubymn_password
 
 development:
-  adapter: postgresql
+  <<: *default
   database: rubymn_dev
-  pool: 5
-  timeout: 5000
-
+  
 test:
-  adapter: postgresql
+  <<: *default
   database: rubymn_test
-  pool: 5
-  timeout: 5000

--- a/test_app.sh
+++ b/test_app.sh
@@ -1,26 +1,18 @@
 #!/bin/bash
 # Proper header for a Bash script.
 
-#!/bin/bash
+APP_DB_NAME_DEV='rubymn_dev'
+APP_DB_NAME_TEST='rubymn_test'
+APP_DB_USER='rubymn_user'
+APP_DB_PASS='rubymn_password'
 
 # Set up PostgreSQL
 echo '---------------------'
 echo 'Setting up PostgreSQL'
-PG_VERSION="$(ls /etc/postgresql)"
-PG_HBA="/etc/postgresql/$PG_VERSION/main/pg_hba.conf"
 
-# Change the settings in the pg_hba.conf file
-sudo bash -c "echo '# Database administrative login by Unix domain socket' > $PG_HBA"
-sudo bash -c "echo 'local   all             postgres                                peer' >> $PG_HBA"
-sudo bash -c "echo 'local   all             all                                     peer' >> $PG_HBA"
-sudo bash -c "echo 'host    all             all             127.0.0.1/32            md5'  >> $PG_HBA"
-sudo bash -c "echo 'host    all             all             ::1/128                 md5'  >> $PG_HBA"
-
-sudo /etc/init.d/postgresql restart # Restart PostgreSQL
-
-sudo -u postgres psql -c"CREATE ROLE $USER WITH CREATEDB LOGIN PASSWORD '';"
-sudo -u postgres psql -c"CREATE DATABASE rubymn_dev WITH OWNER=$USER;"
-sudo -u postgres psql -c"CREATE DATABASE rubymn_test WITH OWNER=$USER;"
+sudo -u postgres psql -c"CREATE ROLE $APP_DB_USER WITH CREATEDB LOGIN PASSWORD '$APP_DB_PASS';"
+sudo -u postgres psql -c"CREATE DATABASE $APP_DB_NAME_DEV WITH OWNER=$APP_DB_USER;"
+sudo -u postgres psql -c"CREATE DATABASE $APP_DB_NAME_TEST WITH OWNER=$APP_DB_USER;"
 
 echo '--------------'
 echo 'bundle install'


### PR DESCRIPTION
Under the old configuration, the app runs, but the database is not accessible through pgAdmin3 when the app is run in Vagrant.

The new setup allows pgAdmin3 to access the database when the app is run in Vagrant through https://github.com/jhsu802701/vagrant-debian-jessie-rbenv-rubymn .

Running the test_app.sh script in the development environment sets up PostgreSQL to comply with the parameters specified in config/database.yml.